### PR TITLE
Fix `FrozenError` in Rails tests

### DIFF
--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -3,12 +3,14 @@ require "minitest/autorun"
 require "bundler/setup"
 require "climate_control"
 require "minitest/around/unit"
+require "active_support/testing/isolation"
 
 require_relative "test_rails_app/app"
 
 POSTGRES_HOST = ENV["DATABASE_HOST"] || "localhost"
 
 class TestFlyRails < Minitest::Test
+  include ActiveSupport::Testing::Isolation
   include Rack::Test::Methods
 
   attr_reader :app
@@ -52,6 +54,8 @@ class TestFlyRails < Minitest::Test
 end
 
 class TestBadEnv < Minitest::Test
+  include ActiveSupport::Testing::Isolation
+
   def setup
     Fly.configuration.primary_region = nil
   end


### PR DESCRIPTION
Rails does not support multiple application instances (per process), and, since transitioning to Zeitwerk, calling `initialize!` on additional application instances raises a "FrozenError: can't modify frozen Array" error.  (See [rails/rails#42319][] for more information.)

This commit makes each `TestFlyRails` and `TestBadEnv` test run in its own process so that there is only one application instance per process.

This also prevents the environment variables set in `TestFlyRails#setup` from affecting other (randomly ordered) tests, such as `TestBadEnv#test_middleware_skipped_without_required_env_vars`.

[rails/rails#42319]: https://github.com/rails/rails/issues/42319