### PR TITLE
Silence "Middleware not loaded" in test output

### DIFF
--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -3,12 +3,14 @@ require "minitest/autorun"
 require "bundler/setup"
 require "climate_control"
 require "minitest/around/unit"
+require "active_support/testing/isolation"
 
 require_relative "test_rails_app/app"
 
 POSTGRES_HOST = ENV["DATABASE_HOST"] || "localhost"
 
 class TestFlyRails < Minitest::Test
+  include ActiveSupport::Testing::Isolation
   include Rack::Test::Methods
 
   attr_reader :app
@@ -52,6 +54,8 @@ class TestFlyRails < Minitest::Test
 end
 
 class TestBadEnv < Minitest::Test
+  include ActiveSupport::Testing::Isolation
+
   def setup
     Fly.configuration.primary_region = nil
   end

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -61,7 +61,9 @@ class TestBadEnv < Minitest::Test
   end
 
   def test_middleware_skipped_without_required_env_vars
-    make_basic_app
+    assert_output %r/middleware not loaded/i do
+      make_basic_app
+    end
     refute Rails.application.middleware.find_index(Fly::RegionalDatabase)
   end
 end


### PR DESCRIPTION
This cleans up the test output, and adds an extra assertion.

**Before:**

  ```
  # Running:

  ..........Warning: DATABASE_URL, PRIMARY_REGION and FLY_REGION must be set to activate the fly-ruby middleware. Middleware not loaded.
  ..

  Finished in 1.451207s, 8.2690 runs/s, 15.8489 assertions/s.
  12 runs, 23 assertions, 0 failures, 0 errors, 0 skips
  ```

**After:**

  ```
  # Running:

  ............

  Finished in 1.595744s, 7.5200 runs/s, 15.6667 assertions/s.
  12 runs, 25 assertions, 0 failures, 0 errors, 0 skips
  ```

---

This is based on top of #13.  See the 2nd commit for the relevant changes.
