### PR TITLE
Add `frozen_string_literal` magic comments

### DIFF
--- a/lib/fly-ruby.rb
+++ b/lib/fly-ruby.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "fly-ruby/configuration"
 require_relative "fly-ruby/regional_database"
 require_relative "fly-ruby/headers"

--- a/lib/fly-ruby/configuration.rb
+++ b/lib/fly-ruby/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fly
   class Configuration
     # Set the region where this instance of the application is deployed

--- a/lib/fly-ruby/headers.rb
+++ b/lib/fly-ruby/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fly
   class Headers
     def initialize(app)

--- a/lib/fly-ruby/railtie.rb
+++ b/lib/fly-ruby/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Fly::Railtie < Rails::Railtie
   def hijack_database_connection
     ActiveSupport::Reloader.to_prepare do

--- a/lib/fly-ruby/regional_database.rb
+++ b/lib/fly-ruby/regional_database.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake'
 
 module Fly

--- a/lib/fly-ruby/version.rb
+++ b/lib/fly-ruby/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fly
   VERSION = "0.3.0"
 end

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -3,12 +3,14 @@ require "minitest/autorun"
 require "bundler/setup"
 require "climate_control"
 require "minitest/around/unit"
+require "active_support/testing/isolation"
 
 require_relative "test_rails_app/app"
 
 POSTGRES_HOST = ENV["DATABASE_HOST"] || "localhost"
 
 class TestFlyRails < Minitest::Test
+  include ActiveSupport::Testing::Isolation
   include Rack::Test::Methods
 
   attr_reader :app
@@ -52,6 +54,8 @@ class TestFlyRails < Minitest::Test
 end
 
 class TestBadEnv < Minitest::Test
+  include ActiveSupport::Testing::Isolation
+
   def setup
     Fly.configuration.primary_region = nil
   end


### PR DESCRIPTION
`# frozen_string_literal: true` automatically freezes all string literals in a file, and avoids allocating a new string each time a string literal is evaluated.

This commit adds `# frozen_string_literal: true` to all files in `lib/`.  This primarily benefits `lib/fly-ruby/regional_database.rb` and (to a lesser extent) `lib/fly-ruby/headers.rb`, because their string literals would be re-allocated on every request, but the comment is added to all files for consistency.

---

This is based on top of #13.  See the 2nd commit for the relevant changes.
