### PR TITLE
Improve `ReplayableRequestMiddleware` performance

### DIFF
--- a/lib/fly-ruby/regional_database.rb
+++ b/lib/fly-ruby/regional_database.rb
@@ -53,7 +53,7 @@ module Fly
       end
 
       def replay_request_state(header_value)
-        header_value&.scan(/(.*?)=(.*?)($|;)/)&.detect { |v| v[0] == "state" }&.at(1)
+        header_value&.slice(/(?:^|;)state=([^;]*)/, 1)
       end
 
       def call(env)

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -3,12 +3,14 @@ require "minitest/autorun"
 require "bundler/setup"
 require "climate_control"
 require "minitest/around/unit"
+require "active_support/testing/isolation"
 
 require_relative "test_rails_app/app"
 
 POSTGRES_HOST = ENV["DATABASE_HOST"] || "localhost"
 
 class TestFlyRails < Minitest::Test
+  include ActiveSupport::Testing::Isolation
   include Rack::Test::Methods
 
   attr_reader :app
@@ -52,6 +54,8 @@ class TestFlyRails < Minitest::Test
 end
 
 class TestBadEnv < Minitest::Test
+  include ActiveSupport::Testing::Isolation
+
   def setup
     Fly.configuration.primary_region = nil
   end


### PR DESCRIPTION
This commit improves the performance of `ReplayableRequestMiddleware` by using `slice` plus a targeted regexp to extract the `state` value from `HTTP_FLY_REPLAY_SRC`.  Although this code is unlikely to be a performance hotspot, the change saves a few memory allocations per request (when `HTTP_FLY_REPLAY_SRC` is present).

<details>
  <summary><strong>Benchmark script</strong></summary>

  ```ruby
  # frozen_string_literal: true

  require "benchmark/memory"
  require "benchmark/ips"

  def original_replay_request_state(header_value)
    header_value&.scan(/(.*?)=(.*?)($|;)/)&.detect { |v| v[0] == "state" }&.at(1)
  end

  def new_replay_request_state(header_value)
    header_value&.slice(/(?:^|;)state=([^;]*)/, 1)
  end

  [
    "state=ok",
    "state=ok;not-state=nope",
    "not-state=nope;state=ok;not-state=nope",
  ].each do |header_value|
    puts "=== HTTP_FLY_REPLAY_SRC: #{header_value.inspect} ".ljust(72, "=")
    puts

    Benchmark.memory do |x|
      x.report("before") { original_replay_request_state(header_value) }
      x.report("after") { new_replay_request_state(header_value) }
    end
    puts

    Benchmark.ips do |x|
      x.report("before") { original_replay_request_state(header_value) }
      x.report("after") { new_replay_request_state(header_value) }
      x.compare!
    end
    puts
  end
  ```
</details>

**Output:**

  ```
  === HTTP_FLY_REPLAY_SRC: "state=ok" ====================================

  Calculating -------------------------------------
                before   568.000  memsize (     0.000  retained)
                           7.000  objects (     0.000  retained)
                           3.000  strings (     0.000  retained)
                 after   208.000  memsize (     0.000  retained)
                           2.000  objects (     0.000  retained)
                           1.000  strings (     0.000  retained)

  Warming up --------------------------------------
                before    28.370k i/100ms
                 after   102.026k i/100ms
  Calculating -------------------------------------
                before    286.150k (± 1.0%) i/s -      1.447M in   5.056879s
                 after      1.042M (± 1.1%) i/s -      5.305M in   5.092054s

  Comparison:
                 after:  1042017.6 i/s
                before:   286149.9 i/s - 3.64x  (± 0.00) slower


  === HTTP_FLY_REPLAY_SRC: "state=ok;not-state=nope" =====================

  Calculating -------------------------------------
                before   928.000  memsize (     0.000  retained)
                          12.000  objects (     0.000  retained)
                           6.000  strings (     0.000  retained)
                 after   208.000  memsize (     0.000  retained)
                           2.000  objects (     0.000  retained)
                           1.000  strings (     0.000  retained)

  Warming up --------------------------------------
                before    19.142k i/100ms
                 after   101.591k i/100ms
  Calculating -------------------------------------
                before    192.275k (± 1.2%) i/s -    976.242k in   5.078122s
                 after      1.019M (± 0.8%) i/s -      5.181M in   5.087012s

  Comparison:
                 after:  1018570.5 i/s
                before:   192274.7 i/s - 5.30x  (± 0.00) slower


  === HTTP_FLY_REPLAY_SRC: "not-state=nope;state=ok;not-state=nope" ======

  Calculating -------------------------------------
                before     1.288k memsize (     0.000  retained)
                          17.000  objects (     0.000  retained)
                           6.000  strings (     0.000  retained)
                 after   208.000  memsize (     0.000  retained)
                           2.000  objects (     0.000  retained)
                           1.000  strings (     0.000  retained)

  Warming up --------------------------------------
                before    15.225k i/100ms
                 after    87.500k i/100ms
  Calculating -------------------------------------
                before    152.240k (± 1.1%) i/s -    776.475k in   5.101011s
                 after    882.718k (± 1.0%) i/s -      4.462M in   5.055880s

  Comparison:
                 after:   882717.7 i/s
                before:   152239.9 i/s - 5.80x  (± 0.00) slower
  ```

---

This is based on top of #13.  See the 2nd commit for the relevant changes.
