### PR TITLE
Preserve existing configuration with `Fly.configure`

### DIFF
--- a/lib/fly-ruby.rb
+++ b/lib/fly-ruby.rb
@@ -22,16 +22,14 @@ module Fly
   end
 
   class Instance
-    attr_accessor :configuration
+    attr_writer :configuration
 
-    def initialize
-      self.configuration = Fly::Configuration.new
+    def configuration
+      @configuration ||= Fly::Configuration.new
     end
 
-    def configure
-      configuration = Fly::Configuration.new
-      yield(configuration) if block_given?
-      self.configuration = configuration
+    def configure(&block)
+      configuration.tap(&block)
     end
   end
 end

--- a/test/fly_test.rb
+++ b/test/fly_test.rb
@@ -1,0 +1,32 @@
+require "minitest/autorun"
+require_relative "../lib/fly-ruby"
+
+ENV["TESTING"] = "1"
+
+class FlyTest < Minitest::Test
+  def test_configuration
+    assert_kind_of Fly::Configuration, Fly.configuration
+  end
+
+  def test_configuration_can_be_reset
+    old_configuration = Fly.configuration
+    Fly.configuration = nil
+
+    assert_kind_of Fly::Configuration, Fly.configuration
+    refute_same old_configuration, Fly.configuration
+  end
+
+  def test_configure
+    configuration_from_block = nil
+    Fly.configure { |configuration| configuration_from_block = configuration }
+
+    assert_same Fly.configuration, configuration_from_block
+  end
+
+  def test_configure_preserves_configuration
+    configuration_before_block = Fly.configuration
+    Fly.configure { }
+
+    assert_same configuration_before_block, Fly.configuration
+  end
+end

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -17,10 +17,9 @@ class TestFlyRails < Minitest::Test
 
   def setup
     ENV["DATABASE_URL"] = "postgres://#{POSTGRES_HOST}:5432/fly_ruby_test"
-    Fly.configuration.current_region = "ams"
-    Fly.configuration.primary_region = "iad"
     ENV["PRIMARY_REGION"] = "iad"
     ENV["FLY_REGION"] = "ams"
+    Fly.configuration = nil
     @app = make_basic_app
   end
 
@@ -57,10 +56,12 @@ class TestBadEnv < Minitest::Test
   include ActiveSupport::Testing::Isolation
 
   def setup
-    Fly.configuration.primary_region = nil
+    Fly.configuration = nil
   end
 
   def test_middleware_skipped_without_required_env_vars
+    ENV["PRIMARY_REGION"] = nil
+
     assert_output %r/middleware not loaded/i do
       make_basic_app
     end

--- a/test/regional_database_test.rb
+++ b/test/regional_database_test.rb
@@ -9,6 +9,7 @@ class RegionalDatabaseTest < Minitest::Test
 
   def setup
     ENV['DATABASE_URL'] = 'postgres://localhost:5432'
+    Fly.configuration = nil
     Fly.configure do |config|
       config.primary_region = "iad"
       config.current_region = "ams"


### PR DESCRIPTION
This commit changes `Fly.configure` to not discard the existing configuration before yielding.  This prevents confusing behavior when `Fly.configure` is called from multiple initializers or when `Fly.configure` is called after setting a value on `Fly.configuration`. It is also more in line with e.g. `Rails.application.configure`.