### PR TITLE
Set regional database before Active Record loads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rack-test'
 gem 'minitest'
 gem "rails"
 gem "pg"
+gem "sqlite3"
 gem "climate_control"
 gem "minitest-around"
 gem "m"

--- a/lib/fly-ruby/railtie.rb
+++ b/lib/fly-ruby/railtie.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 class Fly::Railtie < Rails::Railtie
-  def hijack_database_connection
-    ActiveSupport::Reloader.to_prepare do
-      # If we already have a database connection when this initializer runs,
-      # we should reconnect to the region-local database. This may need some additional
-      # hooks for forking servers to work correctly.
-      if defined?(ActiveRecord)
-        config = ActiveRecord::Base.connection_db_config.configuration_hash
-        ActiveRecord::Base.establish_connection(config.symbolize_keys.merge(Fly.configuration.regional_database_config))
-      end
-    end
-  end
-
-  initializer("fly.regional_database") do |app|
+  initializer("fly.regional_database", before: "active_record.initialize_database") do |app|
     # Insert the request middleware high in the stack, but after static file delivery
     app.config.middleware.insert_after ActionDispatch::Executor, Fly::Headers if Fly.configuration.web?
 
@@ -22,8 +10,8 @@ class Fly::Railtie < Rails::Railtie
       # Insert the database exception handler at the bottom of the stack to take priority over other exception handlers
       app.config.middleware.use Fly::RegionalDatabase::DbExceptionHandlerMiddleware
 
-      if Fly.configuration.in_secondary_region?
-        hijack_database_connection
+      if Fly.configuration.hijack_database_connection?
+        ENV["DATABASE_URL"] = Fly.configuration.regional_database_url
       end
     elsif Fly.configuration.web?
       puts "Warning: DATABASE_URL, PRIMARY_REGION and FLY_REGION must be set to activate the fly-ruby middleware. Middleware not loaded."

--- a/test/test_rails_app/app.rb
+++ b/test/test_rails_app/app.rb
@@ -1,5 +1,6 @@
 require "rails"
 require "active_record"
+require "active_record/railtie"
 require "action_view/railtie"
 require "action_controller/railtie"
 
@@ -77,6 +78,8 @@ def make_basic_app
       "RailsTestApp"
     end
   end
+
+  app.config.load_defaults Rails::VERSION::STRING.to_f
 
   app.config.hosts = nil
   app.config.secret_key_base = "test"

--- a/test/test_rails_app/config/database.yml
+++ b/test/test_rails_app/config/database.yml
@@ -1,0 +1,2 @@
+development:
+  adapter: postgresql


### PR DESCRIPTION
This overrides `DATABASE_URL` with the regional database before the [`active_record.initialize_database` initializer][1] runs.  Thus the regional database settings will be merged into the current environment's database configuration before `establish_connection` is called.

Fixes #12.

[1]: https://github.com/rails/rails/blob/v7.0.3/activerecord/lib/active_record/railtie.rb#L271-L280

---

This is based on top of #17. See the 2nd commit for the relevant changes.

@jsierles I've marked this as a draft because I feel like I am missing something.  Why is `DATABASE_URL` not already pointing to the region database when `FLY_REGION` does?  Are we expecting a connection to be established to the original database / `DATABASE_URL` before switching over to the regional database?

Also, the connection hijacking (both before and after this PR) only affects a single database.  What is the story for [multi-DB Rails apps](https://guides.rubyonrails.org/v7.0/active_record_multiple_databases.html)?
