### PR TITLE
Allow customizing which exceptions to catch and trigger a replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ log/
 Gemfile.lock
 .ruby-version
 *.gem
+db/


### PR DESCRIPTION
This PR adds a configuration field `replayable_exceptions`, which defines the exceptions that should be rescued and should trigger replays. We default to PG and Sqlite3 standard exceptions.