### PR TITLE
Fix database connection hijacking

### DIFF
--- a/lib/fly-ruby/railtie.rb
+++ b/lib/fly-ruby/railtie.rb
@@ -6,13 +6,13 @@ class Fly::Railtie < Rails::Railtie
     app.config.middleware.insert_after ActionDispatch::Executor, Fly::Headers if Fly.configuration.web?
 
     if Fly.configuration.eligible_for_activation?
+
+      Fly.configuration.hijack_database_connection!
+
       app.config.middleware.insert_after Fly::Headers, Fly::RegionalDatabase::ReplayableRequestMiddleware
       # Insert the database exception handler at the bottom of the stack to take priority over other exception handlers
       app.config.middleware.use Fly::RegionalDatabase::DbExceptionHandlerMiddleware
 
-      if Fly.configuration.hijack_database_connection?
-        ENV["DATABASE_URL"] = Fly.configuration.regional_database_url
-      end
     elsif Fly.configuration.web?
       puts "Warning: DATABASE_URL, PRIMARY_REGION and FLY_REGION must be set to activate the fly-ruby middleware. Middleware not loaded."
     end

--- a/lib/fly-ruby/version.rb
+++ b/lib/fly-ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Fly
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -9,6 +9,7 @@ class ConfigurationTest < Minitest::Test
     ENV["REDIS_URL"] = "redis://redis.internal:6379"
     ENV["DATABASE_URL"] = "postgresql://db.internal:6379"
     ENV["FLY_REGION"] = "iad"
+    ENV["PRIMARY_REGION"] = "iad"
     @configuration = Fly::Configuration.new
   end
 
@@ -18,7 +19,7 @@ class ConfigurationTest < Minitest::Test
   end
 
   def test_regional_database_config
-    assert_equal "postgresql://iad.db.internal:6379", @configuration.regional_database_url
-    assert_equal "iad.db.internal", @configuration.regional_database_host
+    assert_equal "postgresql://top1.nearest.of.db.internal:6379", @configuration.secondary_database_url
+    assert_equal "postgresql://iad.db.internal:6379", @configuration.primary_database_url
   end
 end


### PR DESCRIPTION
Now the primary connection will be hijacked and forced to use the primary region DNS like: `ams.dbapp.internal`

The secondary connection will use a DNS entry that resolves to the nearest region like: `top1.nearest.of.dbapp.internal`

These settings should apply regardless of the URL set initially, as long as it ends in `dbapp.internal`.